### PR TITLE
FrqTemplate Key Value update

### DIFF
--- a/Templates/frqTemplate.py
+++ b/Templates/frqTemplate.py
@@ -107,12 +107,12 @@ def create_frq_grids():
         if isinstance(frquestions[key][1], str):
             frqs[key] = [
                 create_frq_string(frquestions, i),
-                create_expanded_button(frquestions[key][0], "primary", "550px"),
+                create_expanded_button(frquestions[key][2], "primary", "550px"),
             ]
         else:
             frqs[key] = [
                 create_frq_int(frquestions, i),
-                create_expanded_button(frquestions[key][0], "primary", "550px"),
+                create_expanded_button(frquestions[key][2], "primary", "550px"),
             ]
         i += 1
 


### PR DESCRIPTION
In create_frq_grids function, for the create expanded button, it was calling value 0 in the key when it should have been calling value 2, as value 0 was duplicating the units or secondary part of the question instead of being the question and then the secondary part. This fixes that issue
![Screenshot from 2024-02-09 11-54-00](https://github.com/byuccl/digital_design_colab/assets/143136042/a3a543ec-66cb-466e-93ca-be81bf664808)
![Screenshot from 2024-02-09 11-54-29](https://github.com/byuccl/digital_design_colab/assets/143136042/d3b79feb-10c2-4c7d-b042-1b3a8ac72ade)
