### PR TITLE
Fixes issues with Flip flop table heading and Arithmetic lab toolchain runtimes

### DIFF
--- a/Exercises/flip_flops/files/tt_ff_template.py
+++ b/Exercises/flip_flops/files/tt_ff_template.py
@@ -12,7 +12,7 @@ List
     [1] : The correct answer, MSB is the top row
 """
 tt = {
-    "Q1": [3, "none", "01001100"],
+    "Q1": [3, "SR Latches Transition/Truth Table", "01001100"],
 }
 
 tt_ff = {

--- a/Labs/arithmetic_lab/arithmetic_lab.ipynb
+++ b/Labs/arithmetic_lab/arithmetic_lab.ipynb
@@ -459,7 +459,9 @@
         "id": "IQd2K_jAwbFS"
       },
       "source": [
-        "### Installing the Toolchain"
+        "### Installing the Toolchain\n",
+        "\n",
+        "Click play. This may take up to 4 minutes."
       ]
     },
     {
@@ -544,7 +546,9 @@
         "id": "EzO5bK_Awg2q"
       },
       "source": [
-        "### Compiling with the Toolchain"
+        "### Compiling the Lab with the Toolchain\n",
+        "\n",
+        "This should take up to 3 minutes"
       ]
     },
     {


### PR DESCRIPTION
Added the runtimes for the Arithmetic lab toolchain runtime, and changed the title for the flip flop transtion table to read SR Latch Table instead of 'none'